### PR TITLE
Add support for Claude Sonnet 4.6 model

### DIFF
--- a/src/app/api/agent/browser-use-cloud/route.ts
+++ b/src/app/api/agent/browser-use-cloud/route.ts
@@ -23,6 +23,7 @@ const getBrowserUseClient = (userApiKey?: string) => {
 const mapModelToApiModel = (model: string): string => {
     const modelMap: Record<string, string> = {
         "claude-sonnet-4": "claude-sonnet-4-20250514",
+        "claude-sonnet-4-6": "claude-sonnet-4-6",
         // Add other mappings as needed
     };
     return modelMap[model] || model;

--- a/src/components/chat-input/helpers.tsx
+++ b/src/components/chat-input/helpers.tsx
@@ -116,6 +116,9 @@ export const getShortModelName = (model: string): string => {
         if (modelName === "claude-sonnet-4-5-20250929") {
             return "Claude Sonnet 4.5 CUA";
         }
+        if (modelName === "claude-sonnet-4-6") {
+            return "Claude Sonnet 4.6";
+        }
         if (modelName.toLowerCase().includes("sonnet")) {
             return "Claude Sonnet";
         }

--- a/src/components/chat-input/types.ts
+++ b/src/components/chat-input/types.ts
@@ -17,9 +17,11 @@ export type ModelType =
     | "gpt-4.1"
     | "o3"
     | "claude-sonnet-4"
+    | "claude-sonnet-4-6"
     | "openai/computer-use-preview"
     | "anthropic/claude-haiku-4-5-20251001"
     | "anthropic/claude-sonnet-4-5-20250929"
+    | "anthropic/claude-sonnet-4-6"
     | "openrouter/moonshotai/kimi-k2-thinking"
     | "vertex_ai/gemini-2.0-flash"
     | "vertex_ai/gemini-2.5-flash"
@@ -46,9 +48,9 @@ export const AGENT_LABELS: Record<AgentType, string> = {
 };
 
 export const MODEL_OPTIONS: Record<AgentType, ModelType[]> = {
-    "browser-use": ["browser-use/bu-2.0", "browser-use/bu-1.0", "google/gemini-2.5-flash", "google/gemini-2.5-pro", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview", "openai/gpt-4.1", "openai/gpt-5.2", "openai/gpt-5-mini", "openai/gpt-5-nano", "anthropic/claude-haiku-4.5", "openrouter/moonshotai/kimi-k2-thinking"],
-    "browser-use-cloud": ["browser-use-llm", "gemini-flash-latest", "gpt-4.1", "o3", "claude-sonnet-4"],
-    "stagehand": ["google/gemini-2.5-flash", "google/gemini-2.5-pro", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview", "openai/gpt-4.1", "openai/gpt-5.2", "openai/gpt-5-mini", "anthropic/claude-haiku-4-5-20251001", "openai/computer-use-preview", "openrouter/moonshotai/kimi-k2-thinking"],
+    "browser-use": ["browser-use/bu-2.0", "browser-use/bu-1.0", "google/gemini-2.5-flash", "google/gemini-2.5-pro", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview", "openai/gpt-4.1", "openai/gpt-5.2", "openai/gpt-5-mini", "openai/gpt-5-nano", "anthropic/claude-haiku-4.5", "anthropic/claude-sonnet-4-6", "openrouter/moonshotai/kimi-k2-thinking"],
+    "browser-use-cloud": ["browser-use-llm", "gemini-flash-latest", "gpt-4.1", "o3", "claude-sonnet-4", "claude-sonnet-4-6"],
+    "stagehand": ["google/gemini-2.5-flash", "google/gemini-2.5-pro", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview", "openai/gpt-4.1", "openai/gpt-5.2", "openai/gpt-5-mini", "anthropic/claude-haiku-4-5-20251001", "anthropic/claude-sonnet-4-6", "openai/computer-use-preview", "openrouter/moonshotai/kimi-k2-thinking"],
     "smooth": [], // Smooth uses its own models
     "notte": [
         "vertex_ai/gemini-2.0-flash",

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -30,6 +30,11 @@ export const pricing: Record<string, ModelPricing> = {
         out: 8.0 / 1_000_000,
         cached: 0.5 / 1_000_000,
     },
+    "anthropic/claude-sonnet-4-6": {
+        in: 3.0 / 1_000_000,
+        out: 15.0 / 1_000_000,
+        cached: 0.3 / 1_000_000,
+    },
     "anthropic/claude-haiku-4-5-20251001": {
         in: 1.0 / 1_000_000,
         out: 5.0 / 1_000_000,

--- a/src/lib/security/validation.ts
+++ b/src/lib/security/validation.ts
@@ -51,6 +51,8 @@ export const ALLOWED_MODELS = new Set([
     'claude-sonnet-4-20250514',
     'claude-sonnet-4',
     'claude-sonnet-4-5-20250929',
+    'claude-sonnet-4-6',
+    'anthropic/claude-sonnet-4-6',
     // Google models
     'gemini-pro',
     'gemini-1.5-flash',

--- a/stagehand/src/lib/llm-pricing.ts
+++ b/stagehand/src/lib/llm-pricing.ts
@@ -25,6 +25,11 @@ const pricing: Record<string, { in: number; out: number; cached: number }> = {
         out: 8.0 / 1_000_000,
         cached: 0.5 / 1_000_000,
     },
+    'anthropic/claude-sonnet-4-6': {
+        in: 3.0 / 1_000_000,
+        out: 15.0 / 1_000_000,
+        cached: 0.3 / 1_000_000,
+    },
     'anthropic/claude-haiku-4.5': {
         in: 1.0 / 1_000_000,
         out: 5.0 / 1_000_000,


### PR DESCRIPTION
## Summary
This PR adds support for the new Claude Sonnet 4.6 model across the application, including type definitions, pricing configuration, and UI integration.

## Key Changes
- **Model Type Definition**: Added `claude-sonnet-4-6` and `anthropic/claude-sonnet-4-6` to the `ModelType` union in `types.ts`
- **Model Options**: Integrated Claude Sonnet 4.6 into the model selection for:
  - `browser-use` agent (as `anthropic/claude-sonnet-4-6`)
  - `browser-use-cloud` agent (as `claude-sonnet-4-6`)
  - `stagehand` agent (as `anthropic/claude-sonnet-4-6`)
- **Pricing Configuration**: Added pricing data for `anthropic/claude-sonnet-4-6`:
  - Input: $3.00 per 1M tokens
  - Output: $15.00 per 1M tokens
  - Cached: $0.30 per 1M tokens
- **UI Display**: Added display name mapping for Claude Sonnet 4.6 in the model name helper
- **Security Validation**: Added both model variants to the allowed models allowlist
- **API Mapping**: Added model mapping for `browser-use-cloud` agent to correctly route `claude-sonnet-4-6` requests

## Implementation Details
- Pricing configuration is duplicated across `src/lib/pricing.ts` and `stagehand/src/lib/llm-pricing.ts` to maintain consistency
- The model is available in both short form (`claude-sonnet-4-6`) for cloud agents and full form (`anthropic/claude-sonnet-4-6`) for other agents
- Display name follows the existing naming convention: "Claude Sonnet 4.6"

https://claude.ai/code/session_0125EbDAT4vYXVruYAG95twM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class support for Claude Sonnet 4.6 across the app. You can select it in agents, with pricing, routing, and security configured.

- New Features
  - Added model IDs to types and selections: browser-use (anthropic/claude-sonnet-4-6), browser-use-cloud (claude-sonnet-4-6), stagehand (anthropic/claude-sonnet-4-6).
  - Pricing added in both pricing files: $3.00/M input, $15.00/M output, $0.30/M cached.
  - UI label: "Claude Sonnet 4.6" in the model display helper.
  - Allowlist updated with both model variants.
  - API mapping for browser-use-cloud to route claude-sonnet-4-6 correctly.

<sup>Written for commit fa7c5a4ec3991801aacc6ee0bebca0ec35b8bf39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

