### PR TITLE
fix: add claude-sonnet-4-6 pricing to Python browser-use backend

### DIFF
--- a/agents/server.py
+++ b/agents/server.py
@@ -394,6 +394,11 @@ pricing = {
         "out": 8.0 / 1_000_000,
         "cached": 0.5 / 1_000_000,
     },
+    "anthropic/claude-sonnet-4-6": {
+        "in": 3.0 / 1_000_000,
+        "out": 15.0 / 1_000_000,
+        "cached": 0.3 / 1_000_000,
+    },
     "anthropic/claude-haiku-4.5": {
         "in": 1.0 / 1_000_000,
         "out": 5.0 / 1_000_000,


### PR DESCRIPTION
Adds the missing anthropic/claude-sonnet-4-6 entry to the pricing dict in agents/server.py so compute_cost() uses correct Sonnet 4.6 rates ($3.0/$15.0/$0.3 per 1M tokens) instead of falling back to defaults. This fixes systematically misreported usage.total_cost for browser-use runs with this model.

https://claude.ai/code/session_0125EbDAT4vYXVruYAG95twM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing pricing for anthropic/claude-sonnet-4-6 so compute_cost uses the correct rates ($3/$15/$0.3 per 1M tokens) instead of defaults, fixing misreported usage.total_cost for browser-use runs.

<sup>Written for commit 64d16533a8428eb36674bc2e1e1624ce15a10bd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

