### PR TITLE
docs: acknowledge prior BrowserArena work by Anupam et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,31 @@ Contributions are welcome! Here's how you can help:
 2. 💡 **Suggest features** - Share your ideas for improvements
 3. 🔀 **Submit PRs** - Fix bugs or add new features
 
+## 🙏 Acknowledgments
+
+We want to give credit to **BrowserArena** by Sagnik Anupam, Davis Brown, Shuo Li, Eric Wong, Hamed Hassani, and Osbert Bastani, who independently introduced a similar idea earlier in their paper *"BrowserArena: Evaluating LLM Agents on Real-World Web Navigation Tasks"* (October 2025).
+
+This project was developed independently and without knowledge of their work at the time. We learned of it after the fact and want to acknowledge their prior contribution to the same research direction.
+
+- 📄 Paper: [arXiv:2510.02418](https://arxiv.org/abs/2510.02418)
+- 💻 Repository: [sagnikanupam/browserarena](https://github.com/sagnikanupam/browserarena)
+
+If you use this project in academic work, please also consider citing their paper:
+
+```bibtex
+@misc{anupam2025browserarenaevaluatingllmagents,
+  title={BrowserArena: Evaluating LLM Agents on Real-World Web Navigation Tasks},
+  author={Sagnik Anupam and Davis Brown and Shuo Li and Eric Wong and Hamed Hassani and Osbert Bastani},
+  year={2025},
+  eprint={2510.02418},
+  archivePrefix={arXiv},
+  primaryClass={cs.AI},
+  url={https://arxiv.org/abs/2510.02418}
+}
+```
+
+---
+
 ## 📝 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

- Adds an `Acknowledgments` section to `README.md` crediting the prior **BrowserArena** work by Sagnik Anupam, Davis Brown, Shuo Li, Eric Wong, Hamed Hassani, and Osbert Bastani.
- Explicitly notes that this project was developed independently and without knowledge of their work at the time.
- Links their paper ([arXiv:2510.02418](https://arxiv.org/abs/2510.02418)) and repository ([sagnikanupam/browserarena](https://github.com/sagnikanupam/browserarena)), and includes their BibTeX for downstream academic citation.

## Motivation

After learning about the prior BrowserArena paper (October 2025), the goal is to give proper credit to the original authors who introduced a similar idea earlier. Acknowledging prior art is the right thing to do — it's intellectually honest and respects the original contribution.

## Test plan

- [ ] Verify the new `Acknowledgments` section renders correctly on GitHub between Contributing and License
- [ ] Confirm the arXiv link, repo link, and BibTeX block are valid and correctly formatted

https://claude.ai/code/session_01JPbWew322eGZGFuoMHFwnQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Acknowledgments section to the README crediting the prior BrowserArena work by Sagnik Anupam, Davis Brown, Shuo Li, Eric Wong, Hamed Hassani, and Osbert Bastani. Includes links to their arXiv paper and GitHub repo, a BibTeX citation, and clarifies this project was developed independently.

<sup>Written for commit 6065916643b0b1cccc4ea8b9eda301a4ae337d26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

