### PR TITLE
fix: accurate token counts for CLI agents (playwright/chrome-devtools/agent-browser)

### DIFF
--- a/stagehand/src/lib/sandbox-runner.ts
+++ b/stagehand/src/lib/sandbox-runner.ts
@@ -52,7 +52,16 @@ export interface RunnerResult {
   success: boolean
   duration: number
   metadata: Record<string, unknown>
-  usage: { input_tokens: number; output_tokens: number; cached_tokens: number }
+  // Convention: `input_tokens` is the UNCACHED input only (Anthropic-style).
+  // For Codex we normalize by subtracting `cached_input_tokens` from the raw
+  // OpenAI-style `input_tokens` so both agents share one shape.
+  usage: {
+    input_tokens: number
+    output_tokens: number
+    cached_tokens: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  }
   sdkCostUsd?: number
 }
 
@@ -317,6 +326,8 @@ async function runClaude(params: RunnerParams): Promise<RunnerResult> {
       cached_tokens:
         (finalResult.usage?.cache_creation_input_tokens || 0) +
         (finalResult.usage?.cache_read_input_tokens || 0),
+      cache_creation_input_tokens: finalResult.usage?.cache_creation_input_tokens || 0,
+      cache_read_input_tokens: finalResult.usage?.cache_read_input_tokens || 0,
     },
     sdkCostUsd: finalResult.total_cost_usd || 0,
   }
@@ -431,8 +442,11 @@ async function runCodex(params: RunnerParams): Promise<RunnerResult> {
       failureMessage: failureMessage || undefined,
       toolVersion: getToolVersion(params.mcpType),
     },
+    // OpenAI/Codex convention: `input_tokens` already includes `cached_input_tokens`.
+    // Normalize to the Anthropic convention (uncached-only) so `computeCost`
+    // doesn't double-charge the cached portion.
     usage: {
-      input_tokens: u.input_tokens,
+      input_tokens: Math.max(0, u.input_tokens - u.cached_input_tokens),
       output_tokens: u.output_tokens,
       cached_tokens: u.cached_input_tokens,
     },

--- a/stagehand/src/lib/vercel-sandbox.ts
+++ b/stagehand/src/lib/vercel-sandbox.ts
@@ -141,10 +141,21 @@ export async function runAgentInSandbox(params: SandboxAgentParams): Promise<San
         input_tokens: result.usage.input_tokens,
         output_tokens: result.usage.output_tokens,
         cached_tokens: result.usage.cached_tokens,
-        total_tokens: result.usage.input_tokens + result.usage.output_tokens,
+        // `input_tokens` is uncached-only (see sandbox-runner normalization),
+        // so the displayed total must add cached tokens back in.
+        total_tokens:
+          result.usage.input_tokens +
+          result.usage.output_tokens +
+          (result.usage.cached_tokens || 0),
         total_cost: totalCost,
         llm_cost: llmCost,
         browser_cost: browserCost,
+        ...(result.usage.cache_creation_input_tokens != null && {
+          cache_creation_input_tokens: result.usage.cache_creation_input_tokens,
+        }),
+        ...(result.usage.cache_read_input_tokens != null && {
+          cache_read_input_tokens: result.usage.cache_read_input_tokens,
+        }),
       },
       cost: totalCost,
       duration: result.duration,


### PR DESCRIPTION
## Summary

The Claude Agent SDK and the Codex SDK disagree on whether `input_tokens` includes cached tokens (Claude: excludes; Codex/OpenAI Responses: includes as a subset). The sandbox runner treated both the same, causing two visible inaccuracies across all three CLI tools (`playwright-mcp`, `chrome-devtools-mcp`, `agent-browser`):

- **Claude runs**: displayed `total_tokens = input + output` silently dropped all cached tokens. With heavy prompt caching in agent workflows, real usage was often many times higher than what was shown.
- **Codex runs**: `computeCost` double-charged the cached portion — once at the full input rate (because `input_tokens` already includes cached) and again at the cached rate.

### Fix

Normalize at the runner boundary to `input_tokens = uncached only` for both SDKs:

- `runClaude` — Claude already emits in this shape; now additionally passes through `cache_creation_input_tokens` (~1.25× input price) and `cache_read_input_tokens` (~0.1× input price) separately so future pricing / analytics can tell them apart.
- `runCodex` — subtract `cached_input_tokens` from Codex's raw `input_tokens` so `computeCost` no longer double-charges.
- `vercel-sandbox.ts` — `total_tokens` now includes `cached_tokens`, matching what the model actually processed.

Claude's cost path (`sdkCostUsd` from the SDK) was already correct and is unchanged.

### Not a bug (verified)

I initially suspected `runCodex` was losing prior turns because `usage` is overwritten on each `turn.completed`. Confirmed from the Codex SDK source (`thread.ts` does the same): a single `runStreamed()` produces exactly one `turn.completed` whose `usage` is cumulative for that turn. No accumulation needed.

## Test plan

- [x] `cd stagehand && npx tsc -p tsconfig.json --noEmit` — passes
- [x] root `npx tsc -p tsconfig.json --noEmit` — passes
- [ ] Run one task per agent × cli-tool matrix (claude-code/codex × playwright/chrome-devtools/agent-browser) and verify the displayed token count reflects cache-heavy runs

https://claude.ai/code/session_01HjgNwUv7cqFAuZsqq9mTos

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix token accounting across the sandbox runner so CLI agents show accurate totals and Codex costs aren’t double-charged. Affects `playwright-mcp`, `chrome-devtools-mcp`, and `agent-browser`.

- **Bug Fixes**
  - Normalize usage: `input_tokens` = uncached-only; report `cached_tokens` separately.
  - Claude: pass through `cache_creation_input_tokens` and `cache_read_input_tokens`; existing `sdkCostUsd` path unchanged.
  - Codex + UI: subtract `cached_input_tokens` from raw `input_tokens` to stop double-charge; in `vercel-sandbox`, `total_tokens` = input + output + cached and the two cache fields are exposed.

<sup>Written for commit 721b748ac53b39cdf4753ff88009ab3c1f4d1744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

